### PR TITLE
Add support for macOS notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ as the gold standard for UI programming!
 Dependencies include
 [pycairo, PyGObject](https://pygobject.readthedocs.io/en/latest/getting_started.html),
 and [pyyaml](https://pyyaml.org/wiki/PyYAMLDocumentation). Additionally, Linux
-users will need [notify2](https://pypi.org/project/notify2/) and Windows users
+users will need [notify2](https://pypi.org/project/notify2/), Windows users
 will need [win10toast](https://github.com/jithurjacob/Windows-10-Toast-Notifications)
-and its dependencies for notifications.
+and its dependencies for notifications, and macOS users will need
+[pyobjc](https://pypi.org/project/pyobjc/)
 
 ## Usage
 To run the application, simply run main.py with Python 3. Save data is stored in

--- a/Tracker.py
+++ b/Tracker.py
@@ -6,6 +6,8 @@ if sys.platform == 'linux':
     import notifications.LinuxNotifications as Notifications
 elif sys.platform == 'win32':
     import notifications.Win32Notifications as Notifications
+elif sys.platform == 'darwin':
+    import notifications.DarwinNotifications as Notifications
 else:
     import notifications.DummyNotifications as Notifications
 

--- a/notifications/DarwinNotifications.py
+++ b/notifications/DarwinNotifications.py
@@ -1,0 +1,16 @@
+# These imports are part of pyobjc:
+from Foundation import NSUserNotification
+from Foundation import NSUserNotificationCenter
+from Foundation import NSUserNotificationDefaultSoundName
+
+def send_notification(title, text, wantSound=True):
+    # Use NSUserNotification to construct our notification:
+    notification = NSUserNotification.alloc().init()
+    notification.setTitle_(title)
+    notification.setInformativeText_(text)
+    if wantSound:
+        notification.setSoundName_(NSUserNotificationDefaultSoundName)
+
+    # Now, deliver that notification to the default macOS notification center:
+    center = NSUserNotificationCenter.defaultUserNotificationCenter()
+    center.deliverNotification_(notification)


### PR DESCRIPTION
This PR implements DarwinNotifications.py, using Foundation from pyobjc to display native macOS notifications in its notification center.